### PR TITLE
Add VM: Add VM analytics-vm

### DIFF
--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -8,3 +8,19 @@ vm_config = {
     region = "eastus"
   }
 }
+
+To add the requested VM entry for `analytics-vm` in the Terraform variable block format, you can use the following HCL code snippet. This assumes you have a variable defined for VM instances in your `terraform.tfvars` file.
+
+Here’s the new entry you can append:
+
+```hcl
+vm_instances = [
+  {
+    name   = "analytics-vm"
+    size   = "Standard_B2s"
+    region = "eastus"
+  }
+]
+```
+
+You can append this to your existing `terraform.tfvars` file under the appropriate variable for your VM instances. If you have other VM entries in an array, make sure to include this new entry within that array.


### PR DESCRIPTION
Automated update from OpenAI request:

Size Standard_B2s, region eastus

Added block:
```
To add the requested VM entry for `analytics-vm` in the Terraform variable block format, you can use the following HCL code snippet. This assumes you have a variable defined for VM instances in your `terraform.tfvars` file.

Here’s the new entry you can append:

```hcl
vm_instances = [
  {
    name   = "analytics-vm"
    size   = "Standard_B2s"
    region = "eastus"
  }
]
```

You can append this to your existing `terraform.tfvars` file under the appropriate variable for your VM instances. If you have other VM entries in an array, make sure to include this new entry within that array.
```